### PR TITLE
Support multi-value solr fields

### DIFF
--- a/solr-hive-core-0.13/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
+++ b/solr-hive-core-0.13/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
@@ -12,6 +12,7 @@ import org.apache.hadoop.hive.serde.Constants;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
@@ -28,125 +29,132 @@ import org.slf4j.LoggerFactory;
 
 public class LWSerDe implements SerDe {
 
-  private static final Logger LOG = LoggerFactory.getLogger(LWSerDe.class);
+	private static final Logger LOG = LoggerFactory.getLogger(LWSerDe.class);
 
-  protected StructTypeInfo typeInfo;
-  protected ObjectInspector inspector;
-  protected List<String> colNames;
-  protected List<TypeInfo> colTypes;
-  protected List<Object> row;
-  private JobConf conf;
+	protected StructTypeInfo typeInfo;
+	protected ObjectInspector inspector;
+	protected List<String> colNames;
+	protected List<TypeInfo> colTypes;
+	protected List<Object> row;
+	private JobConf conf;
 
-  @Override
-  public void initialize(Configuration conf, Properties tblProperties) throws SerDeException {
+	@Override
+	public void initialize(Configuration conf, Properties tblProperties) throws SerDeException {
 
-    colNames = Arrays.asList(tblProperties.getProperty(Constants.LIST_COLUMNS).split(","));
-    colTypes = TypeInfoUtils
-        .getTypeInfosFromTypeString(tblProperties.getProperty(Constants.LIST_COLUMN_TYPES));
-    typeInfo = (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
-    inspector = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(typeInfo);
-    row = new ArrayList<Object>();
+		colNames = Arrays.asList(tblProperties.getProperty(Constants.LIST_COLUMNS).split(","));
+		colTypes = TypeInfoUtils.getTypeInfosFromTypeString(tblProperties.getProperty(Constants.LIST_COLUMN_TYPES));
+		typeInfo = (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
+		inspector = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(typeInfo);
+		row = new ArrayList<Object>();
 
-    try {
-      LWDocumentProvider.init((JobConf) conf);
-      this.conf = (JobConf) conf;
-    } catch (Exception e) {
-      LOG.warn("LWDocumentFactoryHandler not initialize");
-    }
-  }
+		try {
+			LWDocumentProvider.init((JobConf) conf);
+			this.conf = (JobConf) conf;
+		} catch (Exception e) {
+			LOG.warn("LWDocumentFactoryHandler not initialize");
+		}
+	}
 
-  @Override
-  public Object deserialize(Writable data) throws SerDeException {
-    if (!(data instanceof LWDocumentWritable)) {
-      return null;
-    }
+	@Override
+	public Object deserialize(Writable data) throws SerDeException {
+		if (!(data instanceof LWDocumentWritable)) {
+			return null;
+		}
 
-    row.clear();
-    LWDocument doc = ((LWDocumentWritable) data).getLWDocument();
+		row.clear();
+		LWDocument doc = ((LWDocumentWritable) data).getLWDocument();
 
-    for (String fieldName : typeInfo.getAllStructFieldNames()) {
-      if (fieldName.equalsIgnoreCase("id")) {
-        String id = doc.getId();
-        if (id != null) {
-          row.add(doc.getId());
-          continue;
-        }
-      }
-      // Just add first element for now
-      Object firstField = doc.getFirstFieldValue(fieldName);
-      if (firstField != null) {
-        row.add(firstField);
+		for (String fieldName : typeInfo.getAllStructFieldNames()) {
+			if (fieldName.equalsIgnoreCase("id")) {
+				String id = doc.getId();
+				if (id != null) {
+					row.add(doc.getId());
+					continue;
+				}
+			}
+			// Just add first element for now
+			Object firstField = doc.getFirstFieldValue(fieldName);
+			if (firstField != null) {
+				row.add(firstField);
 
-      }
-    }
+			}
+		}
 
-    return row;
-  }
+		return row;
+	}
 
-  @Override
-  public ObjectInspector getObjectInspector() throws SerDeException {
-    return inspector;
-  }
+	@Override
+	public ObjectInspector getObjectInspector() throws SerDeException {
+		return inspector;
+	}
 
-  @Override
-  public Class<? extends Writable> getSerializedClass() {
-    return LWDocumentWritable.class;
-  }
+	@Override
+	public Class<? extends Writable> getSerializedClass() {
+		return LWDocumentWritable.class;
+	}
 
-  @Override
-  public SerDeStats getSerDeStats() {
-    // Nothing for now
-    return null;
-  }
+	@Override
+	public SerDeStats getSerDeStats() {
+		// Nothing for now
+		return null;
+	}
 
-  @Override
-  public Writable serialize(Object data, ObjectInspector objInspector) throws SerDeException {
+	@Override
+	public Writable serialize(Object data, ObjectInspector objInspector) throws SerDeException {
 
-    // Make sure we have a struct, as Hive "root" fields should be a struct
-    if (objInspector.getCategory() != Category.STRUCT) {
-      throw new SerDeException("Unable to serialize root type of " + objInspector.getTypeName());
-    }
+		// Make sure we have a struct, as Hive "root" fields should be a struct
+		if (objInspector.getCategory() != Category.STRUCT) {
+			throw new SerDeException("Unable to serialize root type of " + objInspector.getTypeName());
+		}
 
-    // Our doc
-    LWDocument doc = LWDocumentProvider.createDocument();
+		// Our doc
+		LWDocument doc = LWDocumentProvider.createDocument();
 
-    // Fields...
-    StructObjectInspector inspector = (StructObjectInspector) objInspector;
-    List<? extends StructField> fields = inspector.getAllStructFieldRefs();
+		// Fields...
+		StructObjectInspector inspector = (StructObjectInspector) objInspector;
+		List<? extends StructField> fields = inspector.getAllStructFieldRefs();
 
-    for (int i = 0; i < fields.size(); i++) {
-      StructField f = fields.get(i);
-      String docFieldName = colNames.get(i);
+		for (int i = 0; i < fields.size(); i++) {
+			StructField f = fields.get(i);
+			String docFieldName = colNames.get(i);
 
-      if (docFieldName.equalsIgnoreCase("id")) {
-        if (f.getFieldObjectInspector().getCategory() == Category.PRIMITIVE) {
-          Object id = inspector.getStructFieldData(data, f);
-          doc.setId(id.toString()); // We're making a lot of assumption here that this is a string
+			if (docFieldName.equalsIgnoreCase("id")) {
+				if (f.getFieldObjectInspector().getCategory() == Category.PRIMITIVE) {
+					Object id = inspector.getStructFieldData(data, f);
+					doc.setId(id.toString()); // We're making a lot of
+												// assumption here that this is
+												// a string
 
-        } else {
-          throw new SerDeException("id field must be a primitive [String] type");
-        }
+				} else {
+					throw new SerDeException("id field must be a primitive [String] type");
+				}
 
-      } else {
-        switch (f.getFieldObjectInspector().getCategory()) {
-          case PRIMITIVE:
-            Object value = ObjectInspectorUtils
-                .copyToStandardJavaObject(inspector.getStructFieldData(data, f),
-                    f.getFieldObjectInspector());
-            doc.addField(docFieldName, value);
-            break;
+			} else {
+				ObjectInspector foi = f.getFieldObjectInspector();
+				Category foiCategory = foi.getCategory();
+				if (!foiCategory.equals(Category.PRIMITIVE) && !foiCategory.equals(Category.LIST)) {
+					throw new SerDeException("We don't yet support nested types (found "
+							+ f.getFieldObjectInspector().getTypeName() + ")");
+				}
+				Object value = ObjectInspectorUtils.copyToStandardJavaObject(inspector.getStructFieldData(data, f),
+						f.getFieldObjectInspector());
+				if (foiCategory.equals(Category.PRIMITIVE)) {
+					doc.addField(docFieldName, value);
+				} else {
+					ListObjectInspector loi = (ListObjectInspector) f.getFieldObjectInspector();
+					if (loi.getListElementObjectInspector().getCategory() != Category.PRIMITIVE) {
+						throw new SerDeException("We don't support array of non-primitive types (found "
+								+ f.getFieldObjectInspector().getTypeName() + ")");
+					}
+					for (int j = 0; j < loi.getListLength(value); j++) {
+						Object itemValue = ObjectInspectorUtils.copyToStandardJavaObject(loi.getListElement(value, j),
+								loi.getListElementObjectInspector());
+						doc.addField(docFieldName, itemValue);
+					}
+				}
+			}
+		}
 
-          case STRUCT:
-          case MAP:
-          case LIST:
-          case UNION:
-            throw new SerDeException(
-                "We don't yet support nested types (found " + f.getFieldObjectInspector()
-                    .getTypeName() + ")");
-        }
-      }
-    }
-
-    return new LWDocumentWritable(doc);
-  }
+		return new LWDocumentWritable(doc);
+	}
 }

--- a/solr-hive-core-0.13/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
+++ b/solr-hive-core-0.13/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
@@ -12,7 +12,6 @@ import org.apache.hadoop.hive.serde.Constants;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
-import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
@@ -29,132 +28,125 @@ import org.slf4j.LoggerFactory;
 
 public class LWSerDe implements SerDe {
 
-	private static final Logger LOG = LoggerFactory.getLogger(LWSerDe.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LWSerDe.class);
 
-	protected StructTypeInfo typeInfo;
-	protected ObjectInspector inspector;
-	protected List<String> colNames;
-	protected List<TypeInfo> colTypes;
-	protected List<Object> row;
-	private JobConf conf;
+  protected StructTypeInfo typeInfo;
+  protected ObjectInspector inspector;
+  protected List<String> colNames;
+  protected List<TypeInfo> colTypes;
+  protected List<Object> row;
+  private JobConf conf;
 
-	@Override
-	public void initialize(Configuration conf, Properties tblProperties) throws SerDeException {
+  @Override
+  public void initialize(Configuration conf, Properties tblProperties) throws SerDeException {
 
-		colNames = Arrays.asList(tblProperties.getProperty(Constants.LIST_COLUMNS).split(","));
-		colTypes = TypeInfoUtils.getTypeInfosFromTypeString(tblProperties.getProperty(Constants.LIST_COLUMN_TYPES));
-		typeInfo = (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
-		inspector = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(typeInfo);
-		row = new ArrayList<Object>();
+    colNames = Arrays.asList(tblProperties.getProperty(Constants.LIST_COLUMNS).split(","));
+    colTypes = TypeInfoUtils
+        .getTypeInfosFromTypeString(tblProperties.getProperty(Constants.LIST_COLUMN_TYPES));
+    typeInfo = (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
+    inspector = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(typeInfo);
+    row = new ArrayList<Object>();
 
-		try {
-			LWDocumentProvider.init((JobConf) conf);
-			this.conf = (JobConf) conf;
-		} catch (Exception e) {
-			LOG.warn("LWDocumentFactoryHandler not initialize");
-		}
-	}
+    try {
+      LWDocumentProvider.init((JobConf) conf);
+      this.conf = (JobConf) conf;
+    } catch (Exception e) {
+      LOG.warn("LWDocumentFactoryHandler not initialize");
+    }
+  }
 
-	@Override
-	public Object deserialize(Writable data) throws SerDeException {
-		if (!(data instanceof LWDocumentWritable)) {
-			return null;
-		}
+  @Override
+  public Object deserialize(Writable data) throws SerDeException {
+    if (!(data instanceof LWDocumentWritable)) {
+      return null;
+    }
 
-		row.clear();
-		LWDocument doc = ((LWDocumentWritable) data).getLWDocument();
+    row.clear();
+    LWDocument doc = ((LWDocumentWritable) data).getLWDocument();
 
-		for (String fieldName : typeInfo.getAllStructFieldNames()) {
-			if (fieldName.equalsIgnoreCase("id")) {
-				String id = doc.getId();
-				if (id != null) {
-					row.add(doc.getId());
-					continue;
-				}
-			}
-			// Just add first element for now
-			Object firstField = doc.getFirstFieldValue(fieldName);
-			if (firstField != null) {
-				row.add(firstField);
+    for (String fieldName : typeInfo.getAllStructFieldNames()) {
+      if (fieldName.equalsIgnoreCase("id")) {
+        String id = doc.getId();
+        if (id != null) {
+          row.add(doc.getId());
+          continue;
+        }
+      }
+      // Just add first element for now
+      Object firstField = doc.getFirstFieldValue(fieldName);
+      if (firstField != null) {
+        row.add(firstField);
 
-			}
-		}
+      }
+    }
 
-		return row;
-	}
+    return row;
+  }
 
-	@Override
-	public ObjectInspector getObjectInspector() throws SerDeException {
-		return inspector;
-	}
+  @Override
+  public ObjectInspector getObjectInspector() throws SerDeException {
+    return inspector;
+  }
 
-	@Override
-	public Class<? extends Writable> getSerializedClass() {
-		return LWDocumentWritable.class;
-	}
+  @Override
+  public Class<? extends Writable> getSerializedClass() {
+    return LWDocumentWritable.class;
+  }
 
-	@Override
-	public SerDeStats getSerDeStats() {
-		// Nothing for now
-		return null;
-	}
+  @Override
+  public SerDeStats getSerDeStats() {
+    // Nothing for now
+    return null;
+  }
 
-	@Override
-	public Writable serialize(Object data, ObjectInspector objInspector) throws SerDeException {
+  @Override
+  public Writable serialize(Object data, ObjectInspector objInspector) throws SerDeException {
 
-		// Make sure we have a struct, as Hive "root" fields should be a struct
-		if (objInspector.getCategory() != Category.STRUCT) {
-			throw new SerDeException("Unable to serialize root type of " + objInspector.getTypeName());
-		}
+    // Make sure we have a struct, as Hive "root" fields should be a struct
+    if (objInspector.getCategory() != Category.STRUCT) {
+      throw new SerDeException("Unable to serialize root type of " + objInspector.getTypeName());
+    }
 
-		// Our doc
-		LWDocument doc = LWDocumentProvider.createDocument();
+    // Our doc
+    LWDocument doc = LWDocumentProvider.createDocument();
 
-		// Fields...
-		StructObjectInspector inspector = (StructObjectInspector) objInspector;
-		List<? extends StructField> fields = inspector.getAllStructFieldRefs();
+    // Fields...
+    StructObjectInspector inspector = (StructObjectInspector) objInspector;
+    List<? extends StructField> fields = inspector.getAllStructFieldRefs();
 
-		for (int i = 0; i < fields.size(); i++) {
-			StructField f = fields.get(i);
-			String docFieldName = colNames.get(i);
+    for (int i = 0; i < fields.size(); i++) {
+      StructField f = fields.get(i);
+      String docFieldName = colNames.get(i);
 
-			if (docFieldName.equalsIgnoreCase("id")) {
-				if (f.getFieldObjectInspector().getCategory() == Category.PRIMITIVE) {
-					Object id = inspector.getStructFieldData(data, f);
-					doc.setId(id.toString()); // We're making a lot of
-												// assumption here that this is
-												// a string
+      if (docFieldName.equalsIgnoreCase("id")) {
+        if (f.getFieldObjectInspector().getCategory() == Category.PRIMITIVE) {
+          Object id = inspector.getStructFieldData(data, f);
+          doc.setId(id.toString()); // We're making a lot of assumption here that this is a string
 
-				} else {
-					throw new SerDeException("id field must be a primitive [String] type");
-				}
+        } else {
+          throw new SerDeException("id field must be a primitive [String] type");
+        }
 
-			} else {
-				ObjectInspector foi = f.getFieldObjectInspector();
-				Category foiCategory = foi.getCategory();
-				if (!foiCategory.equals(Category.PRIMITIVE) && !foiCategory.equals(Category.LIST)) {
-					throw new SerDeException("We don't yet support nested types (found "
-							+ f.getFieldObjectInspector().getTypeName() + ")");
-				}
-				Object value = ObjectInspectorUtils.copyToStandardJavaObject(inspector.getStructFieldData(data, f),
-						f.getFieldObjectInspector());
-				if (foiCategory.equals(Category.PRIMITIVE)) {
-					doc.addField(docFieldName, value);
-				} else {
-					ListObjectInspector loi = (ListObjectInspector) f.getFieldObjectInspector();
-					if (loi.getListElementObjectInspector().getCategory() != Category.PRIMITIVE) {
-						throw new SerDeException("We don't support array of non-primitive types (found "
-								+ f.getFieldObjectInspector().getTypeName() + ")");
-					}
-					for (int j = 0; j < loi.getListLength(value); j++) {
-						Object itemValue = ObjectInspectorUtils.copyToStandardJavaObject(loi.getListElement(value, j),
-								loi.getListElementObjectInspector());
-						doc.addField(docFieldName, itemValue);
-					}
-				}
-			}
-		}
+      } else {
+        switch (f.getFieldObjectInspector().getCategory()) {
+          case PRIMITIVE:
+            Object value = ObjectInspectorUtils
+                .copyToStandardJavaObject(inspector.getStructFieldData(data, f),
+                    f.getFieldObjectInspector());
+            doc.addField(docFieldName, value);
+            break;
 
-		return new LWDocumentWritable(doc);
-	}
+          case STRUCT:
+          case MAP:
+          case LIST:
+          case UNION:
+            throw new SerDeException(
+                "We don't yet support nested types (found " + f.getFieldObjectInspector()
+                    .getTypeName() + ")");
+        }
+      }
+    }
+
+    return new LWDocumentWritable(doc);
+  }
 }

--- a/solr-hive-core/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
+++ b/solr-hive-core/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
@@ -12,6 +12,7 @@ import org.apache.hadoop.hive.serde.Constants;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
@@ -130,21 +131,27 @@ public class LWSerDe implements SerDe {
         }
 
       } else {
-        switch (f.getFieldObjectInspector().getCategory()) {
-          case PRIMITIVE:
-            Object value = ObjectInspectorUtils
-                .copyToStandardJavaObject(inspector.getStructFieldData(data, f),
-                    f.getFieldObjectInspector());
-            doc.addField(docFieldName, value);
-            break;
-
-          case STRUCT:
-          case MAP:
-          case LIST:
-          case UNION:
-            throw new SerDeException(
-                "We don't yet support nested types (found " + f.getFieldObjectInspector()
-                    .getTypeName() + ")");
+	    ObjectInspector foi = f.getFieldObjectInspector();
+        Category foiCategory = foi.getCategory();
+        if (!foiCategory.equals(Category.PRIMITIVE) && !foiCategory.equals(Category.LIST)) {
+		  throw new SerDeException("We don't yet support nested types (found "
+            + f.getFieldObjectInspector().getTypeName() + ")");
+        }
+        Object value = ObjectInspectorUtils.copyToStandardJavaObject(inspector.getStructFieldData(data, f),
+        f.getFieldObjectInspector());
+        if (foiCategory.equals(Category.PRIMITIVE)) {
+          doc.addField(docFieldName, value);
+        } else {
+          ListObjectInspector loi = (ListObjectInspector) f.getFieldObjectInspector();
+          if (loi.getListElementObjectInspector().getCategory() != Category.PRIMITIVE) {
+            throw new SerDeException("We don't support arrays of non-primitive types (found "
+              + f.getFieldObjectInspector().getTypeName() + ")");
+          }
+          for (int j = 0; j < loi.getListLength(value); j++) {
+            Object itemValue = ObjectInspectorUtils.copyToStandardJavaObject(loi.getListElement(value, j),
+              loi.getListElementObjectInspector());
+            doc.addField(docFieldName, itemValue);
+          }
         }
       }
     }

--- a/solr-hive-core/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
+++ b/solr-hive-core/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
@@ -130,22 +130,28 @@ public class LWSerDe implements SerDe {
         }
 
       } else {
-        switch (f.getFieldObjectInspector().getCategory()) {
-          case PRIMITIVE:
-            Object value = ObjectInspectorUtils
-                .copyToStandardJavaObject(inspector.getStructFieldData(data, f),
-                    f.getFieldObjectInspector());
-            doc.addField(docFieldName, value);
-            break;
-
-          case STRUCT:
-          case MAP:
-          case LIST:
-          case UNION:
-            throw new SerDeException(
-                "We don't yet support nested types (found " + f.getFieldObjectInspector()
-                    .getTypeName() + ")");
-        }
+        ObjectInspector foi = f.getFieldObjectInspector();
+		Category foiCategory = foi.getCategory();
+		if (!foiCategory.equals(Category.PRIMITIVE) && !foiCategory.equals(Category.LIST)) {
+			throw new SerDeException("We don't yet support nested types (found "
+					+ f.getFieldObjectInspector().getTypeName() + ")");
+		}
+		Object value = ObjectInspectorUtils.copyToStandardJavaObject(inspector.getStructFieldData(data, f),
+				f.getFieldObjectInspector());
+		if (foiCategory.equals(Category.PRIMITIVE)) {
+			doc.addField(docFieldName, value);
+		} else {
+			ListObjectInspector loi = (ListObjectInspector) f.getFieldObjectInspector();
+			if (loi.getListElementObjectInspector().getCategory() != Category.PRIMITIVE) {
+				throw new SerDeException("We don't support array of non-primitive types (found "
+						+ f.getFieldObjectInspector().getTypeName() + ")");
+			}
+			for (int j = 0; j < loi.getListLength(value); j++) {
+				Object itemValue = ObjectInspectorUtils.copyToStandardJavaObject(loi.getListElement(value, j),
+						loi.getListElementObjectInspector());
+				doc.addField(docFieldName, itemValue);
+			}
+		}
       }
     }
 

--- a/solr-hive-core/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
+++ b/solr-hive-core/src/main/java/com/lucidworks/hadoop/hive/LWSerDe.java
@@ -130,28 +130,22 @@ public class LWSerDe implements SerDe {
         }
 
       } else {
-        ObjectInspector foi = f.getFieldObjectInspector();
-		Category foiCategory = foi.getCategory();
-		if (!foiCategory.equals(Category.PRIMITIVE) && !foiCategory.equals(Category.LIST)) {
-			throw new SerDeException("We don't yet support nested types (found "
-					+ f.getFieldObjectInspector().getTypeName() + ")");
-		}
-		Object value = ObjectInspectorUtils.copyToStandardJavaObject(inspector.getStructFieldData(data, f),
-				f.getFieldObjectInspector());
-		if (foiCategory.equals(Category.PRIMITIVE)) {
-			doc.addField(docFieldName, value);
-		} else {
-			ListObjectInspector loi = (ListObjectInspector) f.getFieldObjectInspector();
-			if (loi.getListElementObjectInspector().getCategory() != Category.PRIMITIVE) {
-				throw new SerDeException("We don't support array of non-primitive types (found "
-						+ f.getFieldObjectInspector().getTypeName() + ")");
-			}
-			for (int j = 0; j < loi.getListLength(value); j++) {
-				Object itemValue = ObjectInspectorUtils.copyToStandardJavaObject(loi.getListElement(value, j),
-						loi.getListElementObjectInspector());
-				doc.addField(docFieldName, itemValue);
-			}
-		}
+        switch (f.getFieldObjectInspector().getCategory()) {
+          case PRIMITIVE:
+            Object value = ObjectInspectorUtils
+                .copyToStandardJavaObject(inspector.getStructFieldData(data, f),
+                    f.getFieldObjectInspector());
+            doc.addField(docFieldName, value);
+            break;
+
+          case STRUCT:
+          case MAP:
+          case LIST:
+          case UNION:
+            throw new SerDeException(
+                "We don't yet support nested types (found " + f.getFieldObjectInspector()
+                    .getTypeName() + ")");
+        }
       }
     }
 


### PR DESCRIPTION
Arrays of primitive types in hive can be converted into multi-value Solr fields. This patch should enable it.