### PR TITLE
LWSHADOOP-584: Hadoop projects improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,23 @@ This will make two .jar files, one for use with Hive v0.13 *only*, and another t
 * `solr-hive-serde/build/libs/{packageUser}-hive-serde-{connectorVersion}.jar`
 * `solr-hive-serde-0.13/build/libs/{packageUser}-hive-serde-0.13-{connectorVersion}.jar`
 
+=== Troubleshooting
+
+If GitHub + SSH is not configured the following exception will be thrown:
+
+[source]
+----
+    Cloning into 'solr-hadoop-common'...
+    Permission denied (publickey).
+    fatal: Could not read from remote repository.
+
+    Please make sure you have the correct access rights
+    and the repository exists.
+    fatal: clone of 'git@github.com:LucidWorks/solr-hadoop-common.git' into submodule path 'solr-hadoop-common' failed
+----
+
+Use the next tutorial to fix the exception: https://help.github.com/articles/generating-an-ssh-key/
+
 // end::build-hive[]
 
 // tag: using-serde[]

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,11 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '1.2.2'
+  id 'com.github.johnrengelman.shadow' version '1.2.3'
+}
+
+task wrapper(type: Wrapper) {
+  gradleVersion = '3.0'
 }
 
 defaultTasks 'dist'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ subprojects {
       jcenter()
       mavenCentral()
     }
+    
+    test {
+      reports.html.destination = file("$buildDir/reports/tests")
+      reports.junitXml.destination = file("$buildDir/test-results")
+    }
 
     jacocoTestReport {
       reports {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip


### PR DESCRIPTION
# Related issues:

- LWSHADOOP-584: Build hadoop related projects
- LWSHADOOP-588: Update gradle version of hadoop related projects

# Changes:

- Add "Troubleshooting" to "Build the SerDe Jars" section
- Add wrapper task to gradle build
- Upgrade gradle to 3.0