### PR TITLE
LWSHADOOP-759: Upgrade Hive SerDe to Solr 7.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=com.lucidworks.hadoop
 version=3.0.0
 
-solrVersion=6.6.2
+solrVersion=7.3.1
 hadoop2Version=2.7.1
 
 hiveVersion=1.2.1


### PR DESCRIPTION
All that needed changing was the gradle dependency version, and the
submodule reference to `solr-hadoop-common`.