### PR TITLE
LWSHADOOP-565: Upgrade `hive-solr` to Hive 3

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,9 @@ This project includes tools to build a Hive SerDe to index Hive tables to Solr.
 // end::hive-features[]
 
 
-NOTE: This SerDe does not yet officially support Hive 2.x. Additionally, it should only be used with Solr 5.0 and higher.
+NOTE: This version of `hive-solr` supports Hive 3.0.0.  For support for Hive 1.x, see the `hive_1x` branch.
+
+NOTE: `hive-solr` should only be used with Solr 5.0 and higher.
 
 // tag::build-hive[]
 == Build the SerDe Jars

--- a/build.gradle
+++ b/build.gradle
@@ -46,20 +46,24 @@ subprojects {
       hadoop2Compile.extendsFrom(project.configurations.compile)
       hadoop2TestCompile.extendsFrom(project.configurations.testCompile)
       hadoop2TestRuntime.extendsFrom(project.configurations.testRuntime)
+
+      hadoop3Compile.extendsFrom(project.configurations.compile)
+      hadoop3TestCompile.extendsFrom(project.configurations.testCompile)
+      hadoop3TestRuntime.extendsFrom(project.configurations.testRuntime)
       // Ensure that "project()" deps elsewhere still a copy of the hadoop classes
       it."default".extendsFrom(project.configurations.hadoop2Compile)
     }
 
     compileJava {
-      classpath = configurations.hadoop2Compile
+      classpath = configurations.hadoop3Compile
     }
 
     compileTestJava {
-      classpath = configurations.hadoop2TestCompile + sourceSets.main.output
+      classpath = configurations.hadoop3TestCompile + sourceSets.main.output
     }
     
     test {
-      classpath = configurations.hadoop2TestRuntime + sourceSets.main.output + sourceSets.test.output
+      classpath = configurations.hadoop3TestRuntime + sourceSets.main.output + sourceSets.test.output
       reports.html.destination = file("$buildDir/reports/tests")
       reports.junitXml.destination = file("$buildDir/test-results")
     }
@@ -102,19 +106,19 @@ project('solr-hive-core') {
       exclude group: 'org.apache.hadoop'
       exclude group: 'junit'
     }
-    compile("org.apache.hadoop:hadoop-common:${hadoop2Version}@jar")
-    compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
+    compile("org.apache.hadoop:hadoop-common:${hadoop3Version}@jar")
+    compile("org.apache.hadoop:hadoop-client:${hadoop3Version}") {
       exclude group: 'log4j'
       exclude group: 'org.slf4j'
     }
 
-    compile("org.apache.hadoop:hadoop-auth:${hadoop2Version}") {
+    compile("org.apache.hadoop:hadoop-auth:${hadoop3Version}") {
       transitive = false
     }
-    compile("org.apache.hadoop:hadoop-mapreduce-client-core:${hadoop2Version}") {
+    compile("org.apache.hadoop:hadoop-mapreduce-client-core:${hadoop3Version}") {
       transitive = false
     }
-    compile("org.apache.hadoop:hadoop-hdfs:${hadoop2Version}@jar") {
+    compile("org.apache.hadoop:hadoop-hdfs:${hadoop3Version}@jar") {
       transitive = false
     }
 
@@ -126,7 +130,6 @@ project('solr-hive-core') {
       exclude group: 'junit'
     }
     testCompile "org.apache.mrunit:mrunit:1.0.0:hadoop2@jar"
-    testCompile "com.klarna:hiverunner:3.2.0"
     testCompile "junit:junit:4.12"
     testCompile (project(':solr-hadoop-common:solr-hadoop-testbase')) {
       transitive = false
@@ -134,6 +137,11 @@ project('solr-hive-core') {
     testCompile(project(':solr-hadoop-common:solr-hadoop-document')) {
       transitive = false
     }
+
+    // The com.klarna:hiverunner project doesn't currently support Hive 3, so we temporarily
+    // rely on a custom HiveRunner fork to run tests against a Hive 3 instance.  The code for this
+    // dep can be found here: https://github.com/gerlowskija/HiveRunner/tree/hive_3_0_0
+    testCompile files('libs/hiverunner-hive3-0.0.1.jar')
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,9 @@ version=3.0.0
 
 solrVersion=7.3.1
 hadoop2Version=2.7.1
+hadoop3Version=3.0.0
 
-hiveVersion=1.2.1
+hiveVersion=3.0.0
 
 # Hive buggy version. # Do not change
 hiveBuggyVersion=0.13.0


### PR DESCRIPTION
Hive 3 has been out for some time now, leaving `hive-solr` two major
versions behind much of the Hive/Hadoop community.  This commit fixes by
updating `master` to support the much more modern Hive 3.0.0.

Our Hive integration tests usually rely on the HiveRunner package.
Unfortunately HiveRunner doesn't support Hive3 yet.  So as part of
supporting and testing against Hive3, this commit relies on a modified
HiveRunner jar which does have support for Hive3.  Adding this large binary
file to the repo is painful, and it should be removed from the repo as soon
as a HiveRunner artifact supporting Hive3 is available.