### PR TITLE
Fix default project-dep configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
       hadoop3TestCompile.extendsFrom(project.configurations.testCompile)
       hadoop3TestRuntime.extendsFrom(project.configurations.testRuntime)
       // Ensure that "project()" deps elsewhere still a copy of the hadoop classes
-      it."default".extendsFrom(project.configurations.hadoop2Compile)
+      it."default".extendsFrom(project.configurations.hadoop3Runtime)
     }
 
     compileJava {


### PR DESCRIPTION
Prior to this commit, submodules depending on other submodule projects
did so with a default dep-configuration of 'hadoop2Compile'.  This
commit updates this to a hadoop3 configuration, since that's the more
recent Hadoop version, and the one used by recent releases of HDP.