### PR TITLE
Correct README TBLPROPERTIES typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -310,8 +310,8 @@ CREATE EXTERNAL TABLE solr (id STRING, cat_s STRING, title_s STRING, price_f FLO
      LOCATION '/tmp/solr' --<6>
      TBLPROPERTIES('solr.zkhost' = 'zknode1:2181,zknode2:2181,zknode3:2181/solr',
                    'solr.collection' = 'gettingstarted',
-                   'solr.query' = '*:*'), --<7>
-                   'lww.jaas.file' = '/data/jaas-client.conf'; --<8>
+                   'solr.query' = '*:*', --<7>
+                   'lww.jaas.file' = '/data/jaas-client.conf'); --<8>
 
 
 INSERT OVERWRITE TABLE solr SELECT b.* FROM books b;


### PR DESCRIPTION
An example in our README showed the 'lww.jaas.file' option being
specified outside of a TBLPROPERTIES block, which is invalid HQL syntax.