### PR TITLE
LWSHADOOP-771: Shade 'jline' to prevent beeline conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,8 @@ project('solr-hive-serde') {
     relocate 'org.apache.solr', 'shaded.org.apache.solr'
     // Shade guava due Tez conflicts
     relocate 'com.google.common', 'shaded.com.google.common'
+
+    relocate 'jline', 'shaded.jline'
     // Remove unwanted files in root jar (repackaging)
     exclude 'JDOMAbout*.class'
     exclude '.gitkeep'


### PR DESCRIPTION
Prior to this commit, when our SerDe was loaded by Hive at boottime via
the `hive.aux.jars.path` option, some older jline classes in the serde
conflicted with a later version of jline used by hive.

This commit shades our internal use of jline, to avoid this conflict.