### PR TITLE
Remove Jersey from dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,8 @@ project('solr-hive-serde') {
     dependencies {
       exclude(dependency("org.apache.hadoop:.*"))
       exclude(dependency("org.apache.hive:.*"))
+      exclude(dependency("com.sun.jersey:.*"))
+      exclude(dependency("com.sun.jersey.*:.*"))
     }
 
     relocate 'org.apache.http', 'shaded.org.apache.http'


### PR DESCRIPTION
When the solr-hive-serde is added as UDF to Hive, HiveServer2 fails to communicate with Ranger, and cannot download updated Ranger policies. This is due to a conflict caused by having com.sun.jersey:jersey-client transitive dependency packed in the serde jar. Since jersey-client is not used by solr-hive-serde, it could be excluded from the transitive dependencies.